### PR TITLE
Fix path to static rest-openapi.yaml file reference

### DIFF
--- a/rest/src/main/java/io/jmix/rest/impl/controller/DocumentationController.java
+++ b/rest/src/main/java/io/jmix/rest/impl/controller/DocumentationController.java
@@ -47,7 +47,7 @@ public class DocumentationController {
 
     @RequestMapping(value = "/openapi.yaml", method = RequestMethod.GET, produces = "application/yaml")
     public String getOpenApiYaml() {
-        return resources.getResourceAsString("classpath:io/jmix/rest/api/rest-openapi.yaml");
+        return resources.getResourceAsString("classpath:io/jmix/rest/rest-openapi.yaml");
     }
 
     @RequestMapping(value = "/openapi.json", method = RequestMethod.GET, produces = "application/json")


### PR DESCRIPTION
Currently, the endpoint for the JSON is not responding with the JSON. Instead, a HTTP 500 is returned:

```
GET http://localhost:8080/rest/docs/openapi.json

HTTP/1.1 500 
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: SAMEORIGIN
Content-Type: application/json
Transfer-Encoding: chunked
Date: Thu, 03 Jun 2021 09:13:09 GMT
Connection: close

{
  "error": "Server error",
  "details": ""
}
```

This is due to the fact that the `rest-openapi.yaml` cannot be found. This PR fixes the reference to the file, which is located under `classpath:/io/jmix/rest/rest-openapi.yaml` and not `classpath:/io/jmix/rest/api/rest-openapi.yaml`.

