### PR TITLE
Aligned URLs upper / lowercase for openapi specification

### DIFF
--- a/rest/src/main/java/io/jmix/rest/impl/controller/DocumentationController.java
+++ b/rest/src/main/java/io/jmix/rest/impl/controller/DocumentationController.java
@@ -64,7 +64,7 @@ public class DocumentationController {
         }
     }
 
-    @RequestMapping(value = "/openApiDetailed.yaml", method = RequestMethod.GET, produces = "application/yaml")
+    @RequestMapping(value = "/openapiDetailed.yaml", method = RequestMethod.GET, produces = "application/yaml")
     public String getProjectOpenApiYaml() {
         try {
             OpenAPI openAPI = openAPIGenerator.generateOpenAPI();


### PR DESCRIPTION
Currently, there are two different ways of URLs for the Open API specification:

```
/openApiDetailed.yaml

/openapiDetailed.json
/openapi.json
/openapi.yaml
```

With this PR the URLs are all `openapi`:

```
/openapiDetailed.yaml

/openapiDetailed.json
/openapi.json
/openapi.yaml
```